### PR TITLE
Fixes #2: Privilege escalation

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
     Homepage http://untroubled.org/nullmailer/
   company: ginsys.eu
   license: GPLv3
-  min_ansible_version: 1.2
+  min_ansible_version: 1.9
   platforms:
   #- name: EL
   #  versions:

--- a/tasks/nullmailer.yml
+++ b/tasks/nullmailer.yml
@@ -9,6 +9,7 @@
     mode:   0755
     owner:  root
     group:  root
+  become:   yes
 
 - name:     configure generic mail settings
   action:
@@ -21,6 +22,7 @@
   with_items:
     - mailname
   notify:   restart_nullmailer
+  become:   yes
 
 - name:     configure nullmailer
   action:
@@ -42,10 +44,11 @@
       mode: 0600
     - file: sendtimeout
   notify:   restart_nullmailer
+  become:   yes
 
 - name: install
   action:
     module: apt
     pkg:    nullmailer
     state:  latest
-
+  become:   yes


### PR DESCRIPTION
This will force sudo on those tasks that need require it.

Additionally: currently /etc/nullmailer/remotes is world readable. It should be owned by mail:mail and only readable by the owner, else sensitive information might be leaked.
