### PR TITLE
Ansible templating seems to require explicit string

### DIFF
--- a/tasks/nullmailer.yml
+++ b/tasks/nullmailer.yml
@@ -44,7 +44,7 @@
     - name: pausetime
     - name: remotes
       group: mail
-      mode: 0640
+      mode: '0640'
     - name: sendtimeout
   notify:   restart_nullmailer
   become:       True


### PR DESCRIPTION
Not sure if this is a Version thing or what. I am on Ansible 1.9.4.

Compare before this PR
`-r----xrw- 1 root mail 137 Feb  7 19:56 remotes`
With after
`-rw-r----- 1 root mail 137 Feb  7 19:56 remotes`
