### PR TITLE
Add garbage-collector

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,26 +29,26 @@ nullmailer_remotes:         []
 
 # according to nullmailer docs, me should be equal to hostname
 # but IMHO this must be fully qualified
-nullmailer_me:              '{{ ansible_fqdn }}'
+nullmailer_me:              "{{ ansible_fqdn }}"
 
 # The content of this file is appended to any host name that does not contain
 # a period (except localhost), including defaulthost and idhost.  Defaults to
 # the value of the /etc/mailname system file, if it exists, otherwise the
 # literal name defaultdomain.
-nullmailer_defaultdomain:   '{{ ansible_domain }}'
+nullmailer_defaultdomain:   "{{ ansible_domain }}"
 
 # The content of this file is appended to any address that is missing a host
 # name. Defaults to the value of the /etc/mailname system file, if it exists,
 # otherwise the literal name defaulthost.
-nullmailer_defaulthost:     '{{ ansible_fqdn }}'
+nullmailer_defaulthost:     "{{ ansible_fqdn }}"
 
 # Sets the environment variable $HELOHOST which is used by the SMTP protocol
 # module to set the parameter given to the HELO command.
-nullmailer_helohost:        '{{ nullmailer_me }}'
+nullmailer_helohost:        "{{ nullmailer_me }}"
 
 # The content of this file is used when building the message-id string for the
 # message. Defaults to the canonicalized value of defaulthost.
-nullmailer_idhost:          '{{ nullmailer_defaulthost }}'
+nullmailer_idhost:          "{{ nullmailer_defaulthost }}"
 
 # The number of seconds to pause between successive queue runs when there are
 # messages in the queue. If this is set to 0, nullmailer-send will exit
@@ -60,8 +60,6 @@ nullmailer_pausetime:       60
 # nullmailer-send will wait forever for messages to complete sending.
 nullmailer_sendtimeout:     3600
 
-
 # /etc/mailname: The fully-qualifiled host name of the computer running
 # nullmailer. Defaults to the literal name me.
-nullmailer_mailname:        '{{ nullmailer_me }}'
-
+nullmailer_mailname:        "{{ nullmailer_me }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,9 @@
 ---
 # handlers file for nullmailer
 - name:        restart_nullmailer
-  action:      service name=nullmailer state=restarted
+  service:     
+    name:      nullmailer
+    state:     restarted
+    enabled:   yes
   become:      True
   become_user: '{{ nullmailer_become_user }}'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
     Homepage http://untroubled.org/nullmailer/
   company: ginsys.eu
   license: GPLv3
-  min_ansible_version: 1.9
+  min_ansible_version: 2.0
   platforms:
   #- name: EL
   #  versions:
@@ -26,4 +26,3 @@ galaxy_info:
   - system
   - email
 dependencies: []
-

--- a/tasks/gc.yml
+++ b/tasks/gc.yml
@@ -1,0 +1,28 @@
+---
+
+- name: prepare gc cron
+  cron:
+    cron_file: nullmailer
+    user: root
+    name: MAILTO
+    env: yes
+    value: "{{ nullmailer_adminaddr }}"
+  become: yes
+
+- cron:
+    cron_file: nullmailer
+    user: root
+    name: MAILFROM
+    env: yes
+    value: "{{ ansible_hostname }}@{{ nullmailer_defaulthost }}"
+  become: yes
+
+- name: add gc cron
+  cron:
+    cron_file: nullmailer
+    user: root
+    name: "purge undeliverable"
+    minute: 22
+    hour: 2
+    job: "find /var/spool/nullmailer/queue/ -type f -mtime +1 -delete"
+  become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
+
 - include:  nullmailer.yml
   when:     nullmailer_remotes is defined and nullmailer_adminaddr is defined
   tags:     nullmailer
 
+- include:  gc.yml
+  when:     nullmailer_adminaddr is defined
+  tags:     nullmailer

--- a/tasks/nullmailer.yml
+++ b/tasks/nullmailer.yml
@@ -2,8 +2,7 @@
 # tasks file for nullmailer
 #
 - name:     prepare config dir
-  action:
-    module: file
+  file:
     dest:   /etc/nullmailer
     state:  directory
     mode:   0755
@@ -13,8 +12,7 @@
   become_user:  '{{ nullmailer_become_user }}'
 
 - name:     configure generic mail settings
-  action:
-    module: template
+  template:
     src:    '{{ item + ".j2" }}'
     dest:   /etc/mailname
     mode:   0644
@@ -27,8 +25,7 @@
   become_user:  '{{ nullmailer_become_user }}'
 
 - name:     configure nullmailer
-  action:
-    module: template
+  template:
     src:    '{{ item.name + ".j2" }}'
     dest:   /etc/nullmailer/{{ item.name }}
     mode:   '{{ item.mode |default(0644) }}'
@@ -51,10 +48,8 @@
   become_user:  '{{ nullmailer_become_user }}'
 
 - name: install
-  action:
-    module: apt
+  apt:
     pkg:    nullmailer
     state:  latest
   become:       True
   become_user:  '{{ nullmailer_become_user }}'
-

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for nullmailer


### PR DESCRIPTION
Nullmailer unfortunately does not handle rejected mail deliveries very well and will keep retrying to send an email indefinitely.

A simple cronjob will delete mails older than a day. Maybe we can even make this configurable (and only enable if set to over x-days)?

nullmailer 2.0 seems to come with a feature that avoids all this: https://untroubled.org/nullmailer/NEWS  - but unfortunately neither ubuntu nor debian (sid) are yet on it.


+ some other minor cleanups